### PR TITLE
Fixed usage missing --sudo option.

### DIFF
--- a/bin/mysql-build
+++ b/bin/mysql-build
@@ -282,7 +282,7 @@ function configure_option {
 
 usage() {
   { echo "mysql-build, Compile and Install MySQL"
-    echo "usage: mysql-build [-v|--verbose] [--with-debug] definition prefix [plugin[,...]]"
+    echo "usage: mysql-build [-v|--verbose] [--with-debug] [--sudo] definition prefix [plugin[,...]]"
     echo "       mysql-build --definitions"
     echo "       mysql-build --plugins"
   } >&2


### PR DESCRIPTION
Usage function misses about --sudo option implemented by #7.
