### PR TITLE
Add a test for hard-corded url.

### DIFF
--- a/t/checking_url.t
+++ b/t/checking_url.t
@@ -1,0 +1,32 @@
+use Test::More;
+use LWP::UserAgent;
+
+my @definitions= glob("share/mysql-build/definitions/*");
+
+foreach my $definition (@definitions)
+{
+  open(my $fh, "<", $definition) or die;
+
+  while (my $line= <$fh>)
+  {
+    if ($line =~ qr|(https?://.+\.tar\.gz)|)
+    {
+      my $url= $1;
+      is(request_head($url), 200, $definition)
+    }
+  }
+}
+
+done_testing;
+
+
+sub request_head
+{
+  my ($url)= @_;
+
+  my $ua = LWP::UserAgent->new();
+  my $req= HTTP::Request->new(HEAD => $url);
+  my $res= $ua->request($req);
+
+  return $res->code;
+}


### PR DESCRIPTION
There are some outdated URLs in share/mysql-build/definitions.
(MySQL's recently-CDN has only recent two versions and older versions are moved into archive)

I wrote a simple test, requests by http-HEAD and checks its response-code, for URLs listed share/mysql-build/definitions.
But, I can't decide that does mysql-build go so far as to support outdated(more than recent two) versions.

If you decide mysql-build doesn't support outdated versions, please close this.