### PR TITLE
Fix lost argument through function `build_package`

### DIFF
--- a/bin/mysql-build
+++ b/bin/mysql-build
@@ -197,7 +197,7 @@ build_package() {
   echo "Installing ${package_name}..." >&2
 
   for command in $commands; do
-    "build_package_${command}"
+    "build_package_${command}" "$package_name"
   done
 }
 


### PR DESCRIPTION
`build_package` receives $package_name but doesn't pass it to `build_package_${command}`