### PR TITLE
Add MySQL 8.0.2 dmr

### DIFF
--- a/share/mysql-build/definitions/8.0.2-dmr
+++ b/share/mysql-build/definitions/8.0.2-dmr
@@ -1,0 +1,1 @@
+install_package "mysql-8.0.2-dmr" "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.2-dmr.tar.gz" cmake_local_boost


### PR DESCRIPTION
This pull request supports to install MySQL 8.0.2 dmr.

```
$ mysql-build -v 8.0.2-dmr ~/opt/mysql/mysql-8.0.2-dmr
... snip ...
Installed mysql-8.0.2-dmr to /home/yahonda/opt/mysql/mysql-8.0.2-dmr
```

```
$ cd ~/opt/mysql/mysql-8.0.2-dmr/
$ ./bin/mysqld --initialize-insecure --basedir=.
2017-08-10T02:17:17.522466Z 0 [Note] Basedir set to /home/yahonda/opt/mysql/mysql-8.0.2-dmr/
2017-08-10T02:17:17.855376Z 1 [Warning] InnoDB: New log files created, LSN=89671
2017-08-10T02:17:17.967835Z 1 [Warning] InnoDB: Creating foreign key constraint system tables.
2017-08-10T02:17:18.607825Z 0 [Warning] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 08d608e2-7d72-11e7-8c19-f23c91d487ae.
2017-08-10T02:17:18.610245Z 0 [Warning] Gtid table is not ready to be used. Table 'mysql.gtid_executed' cannot be opened.
2017-08-10T02:17:18.612080Z 5 [Warning] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
```

```
$ ./bin/mysqld_safe &
[1] 27487

$ 2017-08-10T02:17:24.882146Z mysqld_safe Logging to '/home/yahonda/opt/mysql/mysql-8.0.2-dmr/data/li1741-130.members.linode.com.err'.
2017-08-10T02:17:24.898682Z mysqld_safe Starting mysqld daemon with databases from /home/yahonda/opt/mysql/mysql-8.0.2-dmr/data
```

```
$ ./bin/mysql -uroot -e 'SELECT @@version'
+-----------+
| @@version |
+-----------+
| 8.0.2-dmr |
+-----------+
$
```