### PR TITLE
Add MySQL 8.0.28

### DIFF
--- a/bin/mysql-build
+++ b/bin/mysql-build
@@ -232,10 +232,13 @@ build_package_cmake575() {
 build_package_cmake_local_boost() {
   local package_name="$1"
 
-  { CMAKE_OPTIONS="$CMAKE_OPTIONS -DWITH_BOOST=$BUILD_PATH/$package_name/boost"
-    cmake . -DCMAKE_INSTALL_PREFIX="$PREFIX_PATH" $CMAKE_OPTIONS
+  { mkdir working_dir
+    pushd working_dir
+    CMAKE_OPTIONS="$CMAKE_OPTIONS -DWITH_BOOST=$BUILD_PATH/$package_name/boost"
+    cmake ../ -DCMAKE_INSTALL_PREFIX="$PREFIX_PATH" $CMAKE_OPTIONS
     make $MAKE_OPTS
-    $MAKE_INSTALL 
+    $MAKE_INSTALL
+    popd
   } >&4 2>&1
 }
 

--- a/share/mysql-build/definitions/8.0.28
+++ b/share/mysql-build/definitions/8.0.28
@@ -1,0 +1,1 @@
+install_package "mysql-8.0.28" "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.28.tar.gz" cmake_local_boost


### PR DESCRIPTION
I have added MySQL 8.0.28 to be installed by mysql-build.

Since the newer MySQL versions require developer to build out of source,
I have edited `build_package_cmake_local_boost` to conduct out of source build.

This is the message I encountered during the build.

```
CMake Error at CMakeLists.txt:544 (MESSAGE):
  Please do not build in-source.  Out-of source builds are highly
  recommended: you can have multiple builds for the same source, and there is
  an easy way to do cleanup, simply remove the build directory (note that
  'make clean' or 'make distclean' does *not* work)

  You *can* force in-source build by invoking cmake with
  -DFORCE_INSOURCE_BUILD=1
```

`cmake_local_boost` have been used in the following definitions.


```
$ ag 'cmake_local_boost' share/mysql-build/ -l
share/mysql-build/definitions/8.0.12
share/mysql-build/definitions/8.0.13
share/mysql-build/definitions/8.0.11
share/mysql-build/definitions/8.0.28
share/mysql-build/definitions/8.0.2-dmr
share/mysql-build/definitions/8.0.1-dmr
```

I have checked the backward compatibility by running the following command on my Mac.

```
./bin/mysql-build -v $version "$HOME/mysql-build/build_results/$version"
```