### PR TITLE
Use https instead of git protocol for cloning this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The overall structure is loosly borrowed from Sam Stephenson's [ruby-build](http
 ## Installation
 
 ```
-git clone git://github.com/kamipo/mysql-build.git ~/mysql-build
+git clone https://github.com/kamipo/mysql-build.git ~/mysql-build
 
 export PATH="$HOME/mysql-build/bin:$PATH"
 ```


### PR DESCRIPTION
GitHub has disabled git protocol support, and recommends using https instead.
https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting
